### PR TITLE
use os.path.join instad of hardcoded (back)slash

### DIFF
--- a/src/LevelCounter.py
+++ b/src/LevelCounter.py
@@ -5,6 +5,8 @@ Increases that counter if needed. Currently it's range [1;4]
 
 __author__ = 'Kedam'
 
+import os
+
 
 class LevelCounter(object):
     """LevelCounter class"""
@@ -21,4 +23,4 @@ class LevelCounter(object):
     def get_current_level(self):
         """Gets current level counter with maps prefix to make it look better"""
         print self.count
-        return 'maps\\' + str(self.count)
+        return os.path.join('maps', str(self.count))


### PR DESCRIPTION
Using `os.path.join` is more generic - it will not crash on *nix systems, since we use `/` instad of `\` in paths.
